### PR TITLE
Add more config options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,14 @@ os:
 - windows
 rust:
 - stable
+dist: xenial
 addons:
   apt:
     packages:
       - libssl-dev
-cache: cargo
-dist: xenial
+cache:
+  directories:
+    - /home/travis/.cargo
 before_cache:
 - rm -rf /home/travis/.cargo/registry
 before_script:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "g-flite"
-version = "0.2.0"
+version = "0.3.0-rc"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-wamp 0.1.0 (git+https://github.com/golemfactory/golem-client?tag=v0.1.3)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
  "brotli2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "copyless 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -476,9 +476,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chrono"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -789,6 +790,7 @@ dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-wamp 0.1.0 (git+https://github.com/golemfactory/golem-client?tag=v0.1.3)",
  "appdirs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -818,7 +820,7 @@ source = "git+https://github.com/golemfactory/golem-client?tag=v0.1.3#2145fc2b2d
 dependencies = [
  "actix-wamp 0.1.0 (git+https://github.com/golemfactory/golem-client?tag=v0.1.3)",
  "bigdecimal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "golem-rpc-macros 0.1.0 (git+https://github.com/golemfactory/golem-client?tag=v0.1.3)",
@@ -2178,7 +2180,7 @@ dependencies = [
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum cc 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a0c56216487bb80eec9c4516337b2588a4f2a2290d72a1416d930e4dcdb0c90d"
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
-"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
+"checksum chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73abfd4c73d003a674ce5d2933fca6ce6c42480ea84a5ffe0a2dc39ed56300f9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,7 +789,6 @@ dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-wamp 0.1.0 (git+https://github.com/golemfactory/golem-client?tag=v0.1.3)",
  "appdirs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -801,6 +800,7 @@ dependencies = [
  "openssl 0.10.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1701,6 +1701,26 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "structopt"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "subtle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,6 +2321,8 @@ dependencies = [
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
 "checksum string 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0bbfb8937e38e34c3444ff00afb28b0811d9554f15c5ad64d12b0308d1d1995"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
+"checksum structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "g-flite"
-version = "0.2.0"
+version = "0.3.0-rc"
 authors = ["Jakub Konka <jakub.konka@golem.network>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Jakub Konka <jakub.konka@golem.network>"]
 edition = "2018"
 
 [dependencies]
-clap = "2.33.0"
 serde = { version="1.0.91" }
 serde_json = "1.0.39"
 indicatif = "0.11.0"
@@ -20,6 +19,7 @@ golem-rpc-api = { git="https://github.com/golemfactory/golem-client", tag="v0.1.
 golem-rpc-macros = { git="https://github.com/golemfactory/golem-client", tag="v0.1.3" }
 hound = { git="https://github.com/kubkon/hound" }
 openssl = "0.10.20"
+structopt = "0.2.18"
 
 [features]
 openssl_vendored = ["openssl/vendored"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ golem-rpc-macros = { git="https://github.com/golemfactory/golem-client", tag="v0
 hound = { git="https://github.com/kubkon/hound" }
 openssl = "0.10.20"
 structopt = "0.2.18"
+chrono = "0.4.7"
 
 [features]
 openssl_vendored = ["openssl/vendored"]

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,5 +1,4 @@
-use crate::Result;
-
+use super::{GolemOpt, Result};
 use serde_json::{json, Map, Value};
 use std::collections::{BTreeMap, VecDeque};
 use std::fs;
@@ -10,6 +9,9 @@ const FLITE_JS: &[u8] = include_bytes!("../assets/flite.js");
 const FLITE_WASM: &[u8] = include_bytes!("../assets/flite.wasm");
 
 pub struct TaskBuilder {
+    bid: f64,
+    task_timeout: String,
+    subtask_timeout: String,
     js_name: String,
     wasm_name: String,
     input_dir_path: PathBuf,
@@ -19,8 +21,11 @@ pub struct TaskBuilder {
 }
 
 impl TaskBuilder {
-    pub fn new<S: AsRef<Path>>(workspace: S) -> Self {
+    pub fn new<S: AsRef<Path>>(workspace: S, opt: GolemOpt) -> Self {
         Self {
+            bid: opt.bid,
+            task_timeout: opt.task_timeout.to_string(),
+            subtask_timeout: opt.subtask_timeout.to_string(),
             js_name: "flite.js".into(),
             wasm_name: "flite.wasm".into(),
             input_dir_path: workspace.as_ref().join("in"),
@@ -122,9 +127,9 @@ impl TaskBuilder {
         let json = json!({
             "type": "wasm",
             "name": "g_flite",
-            "bid": 1,
-            "subtask_timeout": "00:10:00",
-            "timeout": "00:10:00",
+            "bid": self.bid,
+            "subtask_timeout": self.subtask_timeout,
+            "timeout": self.task_timeout,
             "options": {
                 "js_name": self.js_name,
                 "wasm_name": self.wasm_name,

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -1,0 +1,94 @@
+use chrono::naive::NaiveTime;
+use std::str::FromStr;
+use std::string::ToString;
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Timeout {
+    timeout: NaiveTime,
+}
+
+impl FromStr for Timeout {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let timeout = NaiveTime::parse_from_str(value, "%H:%M:%S").map_err(|err| {
+            format!(
+                "Failed parsing Timeout from '{}' with error: {}",
+                value, err
+            )
+        })?;
+        if timeout == NaiveTime::from_hms(0, 0, 0) {
+            Err("Timeout of '00:00:00' is not allowed".to_owned())
+        } else {
+            Ok(Self { timeout })
+        }
+    }
+}
+
+impl ToString for Timeout {
+    fn to_string(&self) -> String {
+        self.timeout.format("%H:%M:%S").to_string()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn valid_input() {
+        assert_eq!(
+            Timeout::from_str("00:00:10"),
+            Ok(Timeout {
+                timeout: NaiveTime::from_hms(0, 0, 10)
+            })
+        );
+        assert_eq!(
+            Timeout::from_str("00:10:00"),
+            Ok(Timeout {
+                timeout: NaiveTime::from_hms(0, 10, 0)
+            })
+        );
+        assert_eq!(
+            Timeout::from_str("10:00:00"),
+            Ok(Timeout {
+                timeout: NaiveTime::from_hms(10, 0, 0)
+            })
+        );
+        assert_eq!(
+            Timeout::from_str("23:59:59"),
+            Ok(Timeout {
+                timeout: NaiveTime::from_hms(23, 59, 59)
+            })
+        );
+    }
+
+    #[test]
+    fn invalid_input() {
+        assert_eq!(
+            Timeout::from_str("10"),
+            Err("Failed parsing Timeout from '10' with error: premature end of input".to_owned())
+        );
+        assert_eq!(
+            Timeout::from_str("10:00"),
+            Err(
+                "Failed parsing Timeout from '10:00' with error: premature end of input".to_owned()
+            )
+        );
+        assert_eq!(
+            Timeout::from_str(""),
+            Err("Failed parsing Timeout from '' with error: premature end of input".to_owned())
+        );
+        assert_eq!(
+            Timeout::from_str("24:00:00"),
+            Err(
+                "Failed parsing Timeout from '24:00:00' with error: input is out of range"
+                    .to_owned()
+            )
+        );
+        assert_eq!(
+            Timeout::from_str("00:00:00"),
+            Err("Timeout of '00:00:00' is not allowed".to_owned())
+        );
+    }
+}


### PR DESCRIPTION
This PR adds more config options to `g_flite` app. It is now possible to

* specify the bid value for Golem task (default is `1.0`)
* specify the task timeout (default is `00:10:00`)
* specify the subtask timeout (default is `00:10:00`)

As an improvement to general code design, `clap` has been swapped for `structopt` which cleaned up the code nicely.

This PR is also addressing desirable features mentioned in #11.