### PR TITLE
Several improvement in prep for `0.3.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -791,7 +791,7 @@ dependencies = [
  "actix-wamp 0.1.0 (git+https://github.com/golemfactory/golem-client?tag=v0.1.3)",
  "appdirs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "console 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "console 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "golem-rpc-api 0.1.0 (git+https://github.com/golemfactory/golem-client?tag=v0.1.3)",
@@ -944,7 +944,7 @@ name = "indicatif"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "console 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "console 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "number_prefix 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2184,7 +2184,7 @@ dependencies = [
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73abfd4c73d003a674ce5d2933fca6ce6c42480ea84a5ffe0a2dc39ed56300f9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum console 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2bf3720d3f3fc30b721ef1ae54e13af3264af4af39dc476a8de56a6ee1e2184b"
+"checksum console 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8ca57c2c14b8a2bf3105bc9d15574aad80babf6a9c44b1058034cdf8bd169628"
 "checksum copyless 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "59de7722d3b5c7b35dd519d617fe5116c9b879a0f145dc5431d78ab1f61d7c23"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "g-flite"
-version = "0.3.0-rc"
+version = "0.3.0"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-wamp 0.1.0 (git+https://github.com/golemfactory/golem-client?tag=v0.1.3)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 serde = { version="1.0.91" }
 serde_json = "1.0.39"
 indicatif = "0.11.0"
-console = ">=0.7.1, <1.0.0"
+console = "0.7.7"
 actix = "0.8.3"
 log = "0.4.6"
 env_logger = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "g-flite"
-version = "0.3.0-rc"
+version = "0.3.0"
 authors = ["Jakub Konka <jakub.konka@golem.network>"]
 edition = "2018"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ mod timeout;
 
 pub type Result<T> = std::result::Result<T, String>;
 
-use console::style;
+use console::{style, Emoji};
 use env_logger::{Builder, Env};
 use golem_rpc_api::comp::{self, AsGolemComp};
 use hound;
@@ -17,10 +17,10 @@ use std::time::SystemTime;
 use structopt::StructOpt;
 use timeout::Timeout;
 
-static TRUCK: &str = "🚚  ";
-static CLIP: &str = "🔗  ";
-static PAPER: &str = "📃  ";
-static HOURGLASS: &str = "⌛  ";
+static TRUCK: Emoji = Emoji("🚚  ", "");
+static CLIP: Emoji = Emoji("🔗  ", "");
+static PAPER: Emoji = Emoji("📃  ", "");
+static HOURGLASS: Emoji = Emoji("⌛  ", "");
 
 #[derive(Debug, StructOpt)]
 #[structopt(


### PR DESCRIPTION
This PR features a few improvements and bug fixes in prep for `0.3.0` release of `g-flite`:
* fixes bug todo with incorrect input splitting into chunks for odd values
* fixes emoji rendering in unsupported terminal emulators