### PR TITLE
Add handling of ctrl-c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ name = "actix"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "actix-http 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-http 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-rt 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -45,13 +45,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-service 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-utils 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-utils 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-openssl 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -60,15 +60,15 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-connect 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-server-config 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-server-config 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-service 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-threadpool 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-utils 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-utils 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "brotli2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -91,11 +91,11 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -115,8 +115,8 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -136,18 +136,18 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "actix-rt 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-server-config 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-server-config 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-service 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-openssl 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "actix-server-config"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "actix-utils"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -208,42 +208,42 @@ dependencies = [
 [[package]]
 name = "actix-wamp"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/golem-client#53c0fce38a37e8ec52fe70b0a86a0b233b68bae6"
+source = "git+https://github.com/golemfactory/golem-client#f9140a33af42e6ee6f7b0ee250087381cacac1c9"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-http 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-web 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-http 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-web 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmpv 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "actix-web"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-http 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-http 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-router 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-rt 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-server 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-server-config 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-server 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-server-config 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-service 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-threadpool 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-utils 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-utils 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web-codegen 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "awc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -254,10 +254,10 @@ dependencies = [
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -270,7 +270,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -280,7 +280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -339,7 +339,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-http 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-http 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-service 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -347,10 +347,10 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -358,10 +358,10 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace-sys 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -392,7 +392,7 @@ dependencies = [
  "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -483,7 +483,7 @@ dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -531,7 +531,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -594,7 +594,7 @@ dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -605,9 +605,9 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -705,7 +705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -716,7 +716,7 @@ dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -725,7 +725,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -736,7 +736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -815,8 +815,8 @@ dependencies = [
  "hound 3.4.0 (git+https://github.com/kubkon/hound)",
  "indicatif 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "golem-rpc-api"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/golem-client#53c0fce38a37e8ec52fe70b0a86a0b233b68bae6"
+source = "git+https://github.com/golemfactory/golem-client#f9140a33af42e6ee6f7b0ee250087381cacac1c9"
 dependencies = [
  "actix-wamp 0.1.0 (git+https://github.com/golemfactory/golem-client)",
  "bigdecimal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -851,9 +851,9 @@ dependencies = [
  "golem-rpc-macros 0.1.0 (git+https://github.com/golemfactory/golem-client)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_repr 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -862,15 +862,15 @@ dependencies = [
 [[package]]
 name = "golem-rpc-macros"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/golem-client#53c0fce38a37e8ec52fe70b0a86a0b233b68bae6"
+source = "git+https://github.com/golemfactory/golem-client#f9140a33af42e6ee6f7b0ee250087381cacac1c9"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -978,7 +978,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "number_prefix 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -998,7 +998,7 @@ dependencies = [
  "socket2 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "widestring 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "winreg 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winreg 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1122,7 +1122,7 @@ dependencies = [
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "miniz_oxide 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz_oxide 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1251,7 +1251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl"
-version = "0.10.23"
+version = "0.10.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1259,7 +1259,7 @@ dependencies = [
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.47"
+version = "0.9.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1316,7 +1316,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1546,22 +1546,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
-version = "1.1.9"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ucd-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1589,7 +1589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1599,7 +1599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1646,10 +1646,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1657,17 +1657,17 @@ name = "serde_bytes"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1677,7 +1677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1687,7 +1687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1697,7 +1697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1805,7 +1805,7 @@ dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1815,7 +1815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.39"
+version = "0.15.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1830,7 +1830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1928,7 +1928,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2062,7 +2062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ucd-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2193,7 +2193,7 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2220,16 +2220,16 @@ dependencies = [
 "checksum actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "671ce3d27313f236827a5dd153a1073ad03ef31fc77f562020263e7830cf1ef7"
 "checksum actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9f2c11af4b06dc935d8e1b1491dad56bfb32febc49096a91e773f8535c176453"
 "checksum actix-connect 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d161322a26e6b76d6598f48654afbdcfee644c900d4368e9962ec68abd0713b"
-"checksum actix-http 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "47403dd5aaebc1b4ab0757f7f3c6cd92d805086293e651a91898b21dbcc24f07"
+"checksum actix-http 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "59698e11ceb42ea16a2e491bd5a9b48adc7268323a5b600522d408d09783828c"
 "checksum actix-router 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "23224bb527e204261d0291102cb9b52713084def67d94f7874923baefe04ccf7"
 "checksum actix-rt 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "18d9054b1cfacfa441846b9b99001010cb8fbb02130e6cfdb25cea36d3e98e87"
-"checksum actix-server 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ba8c936356c882420eab87051b12ca1926dc42348863d05fff7eb151df9cddbb"
-"checksum actix-server-config 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e78703f07d0bd08b426b482d53569d84f1e1929024f0431b3a5a2dc0c1c60e0f"
+"checksum actix-server 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fb3038e9e457e0a498ea682723e0f4e6cc2c4f362a1868d749808355275ad959"
+"checksum actix-server-config 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "483a34989c682d93142bacad6300375bb6ad8002d2e0bb249dbad86128b9ff30"
 "checksum actix-service 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aaecc01bbc595ebd7a563a7d4f8a607d0b964bb55273c6f362b0b02c26508cf2"
 "checksum actix-threadpool 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1c29f7c554d56b3841f4bb85d5b3dee01ba536e1307679f56eb54de28aaec3fb"
-"checksum actix-utils 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "07d9689cab66e39b2d5aea5d082d10ca36193d23472a93267822599aa2e611be"
+"checksum actix-utils 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6ea501068a0173533704be321f149853f702d9e3c3ce9d57e7a96d94b1ab5aca"
 "checksum actix-wamp 0.1.0 (git+https://github.com/golemfactory/golem-client)" = "<none>"
-"checksum actix-web 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "864123627dea7fe20601e0d26c6c826a4f2a5d7eed87d776b53eba2064b817fa"
+"checksum actix-web 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0147b2fd52ced64145c8370af627f12f098222a1c6ba67d021e21cd0d806f574"
 "checksum actix-web-codegen 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe9e3cdec1e645b675f354766e0688c5705021c85ab3cf739be1c8999b91c76"
 "checksum actix_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0bf5f6d7bf2d220ae8b4a7ae02a572bb35b7c4806b24049af905ab8110de156c"
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
@@ -2240,8 +2240,8 @@ dependencies = [
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
 "checksum awc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4c4763e6aa29a801d761dc3464f081d439ea5249ba90c3c3bdfc8dd3f739d233"
-"checksum backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "18b50f5258d1a9ad8396d2d345827875de4261b158124d4c819d9b351454fae5"
-"checksum backtrace-sys 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "5b3a000b9c543553af61bc01cbfc403b04b5caa9e421033866f2e98061eb3e61"
+"checksum backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "88fb679bc9af8fa639198790a77f52d345fe13656c08b43afa9424c206b731c6"
+"checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bigdecimal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "460825c9e21708024d67c07057cd5560e5acdccac85de0de624a81d3de51bacb"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
@@ -2327,7 +2327,7 @@ dependencies = [
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
 "checksum miniz-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9e3ae51cea1576ceba0dde3d484d30e6e5b86dee0b2d412fe3a16a15c98202"
-"checksum miniz_oxide 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b6c3756d66cf286314d5f7ebe74886188a9a92f5eee68b06f31ac2b4f314c99d"
+"checksum miniz_oxide 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5f6d7b3dd914b70db7cef7ab9dc74339ffcadf4d033464a987237bb0b9418cd4"
 "checksum miniz_oxide_c_api 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5b78ca5446dd9fe0dab00e058731b6b08a8c1d2b9cdb8efb10876e24e9ae2494"
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
@@ -2342,16 +2342,16 @@ dependencies = [
 "checksum number_prefix 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dbf9993e59c894e3c08aa1c2712914e9e6bf1fcbfc6bef283e2183df345a4fee"
 "checksum ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
-"checksum openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)" = "97c140cbb82f3b3468193dd14c1b88def39f341f68257f8a7fe8ed9ed3f628a5"
+"checksum openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)" = "8152bb5a9b5b721538462336e3bef9a539f892715e5037fda0f984577311af15"
 "checksum openssl-src 111.3.0+1.1.1c (registry+https://github.com/rust-lang/crates.io-index)" = "53ed5f31d294bdf5f7a4ba0a206c2754b0f60e9a63b7e3076babc5317873c797"
-"checksum openssl-sys 0.9.47 (registry+https://github.com/rust-lang/crates.io-index)" = "75bdd6dbbb4958d38e47a1d2348847ad1eb4dc205dc5d37473ae504391865acc"
+"checksum openssl-sys 0.9.48 (registry+https://github.com/rust-lang/crates.io-index)" = "b5ba300217253bcc5dc68bed23d782affa45000193866e025329aa8a7a9f05b8"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum parking_lot_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb88cb1cb3790baa6776844f968fea3be44956cf184fa1be5a03341f5491278c"
-"checksum parking_lot_core 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a7bbaa05312363e0480e1efee133fff1a09ef4a6406b65e226b9a793c223a32"
+"checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
@@ -2374,8 +2374,8 @@ dependencies = [
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-"checksum regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d9d8297cc20bbb6184f8b45ff61c8ee6a9ac56c156cec8e38c3e5084773c44ad"
-"checksum regex-syntax 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "9b01330cce219c1c6b2e209e5ed64ccd587ae5c67bed91c0b49eecf02ae40e21"
+"checksum regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6b23da8dfd98a84bd7e08700190a5d9f7d2d38abd4369dd1dae651bc40bfd2cc"
+"checksum regex-syntax 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5485bf1523a9ed51c4964273f22f63f24e31632adb5dad134f488f86a3875c"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
 "checksum rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a3d45d7afc9b132b34a2479648863aa95c5c88e98b32285326a6ebadc80ec5c9"
 "checksum rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "011e1d58446e9fa3af7cdc1fb91295b10621d3ac4cb3a85cc86385ee9ca50cd3"
@@ -2387,9 +2387,9 @@ dependencies = [
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)" = "e47a9fd6b2d2d2330b19b0b3e5248a170a5acd6356fd88c7bb30362ef9c70567"
+"checksum serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "d46b3dfedb19360a74316866cef04687cd4d6a70df8e6a506c63512790769b72"
 "checksum serde_bytes 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)" = "defbb8a83d7f34cc8380751eeb892b825944222888aff18996ea7901f24aec88"
-"checksum serde_derive 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)" = "5ea8eb91549d859275aef70c58bb30bd62ce50e5eb1a52d32b1b6886e02f7bce"
+"checksum serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "c22a0820adfe2f257b098714323563dd06426502abbbce4f51b72ef544c5027f"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum serde_repr 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "29a734c298df0346c4cd5919595981c266dabbf12dc747c85e1a95e96077a52b"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
@@ -2408,7 +2408,7 @@ dependencies = [
 "checksum structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
 "checksum structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
-"checksum syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d960b829a55e56db167e861ddb43602c003c7be0bee1d345021703fac2fb7c"
+"checksum syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)" = "bc945221ccf4a7e8c31222b9d1fc77aefdd6638eb901a6ce457a3dc29d4c31e8"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"
@@ -2430,7 +2430,7 @@ dependencies = [
 "checksum trust-dns-proto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5559ebdf6c2368ddd11e20b11d6bbaf9e46deb803acd7815e93f5a7b4a6d2901"
 "checksum trust-dns-resolver 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c9992e58dba365798803c0b91018ff6c8d3fc77e06977c4539af2a6bfe0a039"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
-"checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
+"checksum ucd-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa9b3b49edd3468c0e6565d85783f51af95212b6fa3986a5500954f00b460874"
 "checksum unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a84e5511b2a947f3ae965dcb29b13b7b1691b6e7332cf5dbc1744138d5acb7f6"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
@@ -2451,6 +2451,6 @@ dependencies = [
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
-"checksum winreg 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "daf67b95d0b1bf421c4f11048d63110ca3719977169eec86396b614c8942b6e0"
+"checksum winreg 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73f1f3c6c4d3cab118551b96c476a2caab920701e28875b64a458f2ecb96ec9d"
 "checksum winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,6 +807,7 @@ dependencies = [
  "appdirs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "golem-rpc-api 0.1.0 (git+https://github.com/golemfactory/golem-client)",
@@ -1161,6 +1171,18 @@ dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2114,6 +2136,11 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "widestring"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,6 +2265,7 @@ dependencies = [
 "checksum crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f0ed1a4de2235cabda8558ff5840bffb97fcb64c97827f354a451307df5f72b"
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
+"checksum ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7dfd2d8b4c82121dfdff120f818e09fc4380b0b7e17a742081a89b94853e87f"
 "checksum derive_more 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6d944ac6003ed268757ef1ee686753b57efc5fcf0ebe7b64c9fc81e7e32ff839"
 "checksum derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a141330240c921ec6d074a3e188a7c7ef95668bb95e7d44fa0e5778ec2a7afe"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
@@ -2305,6 +2333,7 @@ dependencies = [
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+"checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57450397855d951f1a41305e54851b1a7b8f5d2e349543a02a2effe25459f718"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
@@ -2413,6 +2442,7 @@ dependencies = [
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum widestring 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "effc0e4ff8085673ea7b9b2e3c73f6bd4d118810c9009ed8f1e16bd96c331db6"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ hound = { git="https://github.com/kubkon/hound" }
 openssl = "0.10.20"
 structopt = "0.2.18"
 chrono = "0.4.7"
-ctrlc = { version = "3.0", features = ["termination"] }
+ctrlc = "3.0"
 
 [features]
 openssl_vendored = ["openssl/vendored"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Jakub Konka <jakub.konka@golem.network>"]
 edition = "2018"
 
 [dependencies]
-serde = { version="1.0.91" }
+serde = "1.0.91"
 serde_json = "1.0.39"
 indicatif = "0.11.0"
 console = "0.7.7"
@@ -21,6 +21,7 @@ hound = { git="https://github.com/kubkon/hound" }
 openssl = "0.10.20"
 structopt = "0.2.18"
 chrono = "0.4.7"
+ctrlc = { version = "3.0", features = ["termination"] }
 
 [features]
 openssl_vendored = ["openssl/vendored"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,365 @@
+use super::task::{Task, TaskBuilder};
+use super::timeout::Timeout;
+use super::{Opt, Result};
+use console::{style, Emoji};
+use golem_rpc_api::comp::{self, AsGolemComp};
+use hound;
+use indicatif::ProgressBar;
+use std::convert::TryFrom;
+use std::env;
+use std::fs;
+use std::io::Read;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+use std::time::SystemTime;
+
+static TRUCK: Emoji = Emoji("🚚  ", "");
+static CLIP: Emoji = Emoji("🔗  ", "");
+static PAPER: Emoji = Emoji("📃  ", "");
+static HOURGLASS: Emoji = Emoji("⌛  ", "");
+
+#[derive(Debug)]
+pub enum CompFragment<T> {
+    Success(T),
+    CtrlC,
+}
+
+#[derive(Debug)]
+pub struct App {
+    input: PathBuf,
+    output: PathBuf,
+    datadir: PathBuf,
+    address: String,
+    port: u16,
+    subtasks: usize,
+    bid: f64,
+    task_timeout: Timeout,
+    subtask_timeout: Timeout,
+    abort: Arc<AtomicBool>,
+}
+
+impl App {
+    fn split_input(&self) -> Result<CompFragment<Vec<String>>> {
+        let mut contents = String::new();
+        fs::File::open(&self.input)
+            .and_then(|mut f| f.read_to_string(&mut contents))
+            .map_err(|e| format!("reading from '{:?}': {}", self.input, e))?;
+
+        let word_count = contents.split_whitespace().count();
+
+        log::info!("Input text file has {} words", word_count);
+
+        println!(
+            "{} {}Splitting '{}' into {} Golem subtasks...",
+            style("[1/4]").bold().dim(),
+            PAPER,
+            self.input.to_string_lossy(),
+            self.subtasks,
+        );
+
+        let mut chunks = Vec::with_capacity(self.subtasks);
+        let num_words = (word_count as f64 / self.subtasks as f64).ceil() as usize;
+
+        log::info!("Each chunk will have max {} words", num_words);
+
+        let mut acc = Vec::with_capacity(num_words);
+        for word in contents.split_whitespace() {
+            acc.push(word);
+
+            if acc.len() == num_words {
+                chunks.push(acc);
+                acc = Vec::with_capacity(num_words);
+                continue;
+            }
+        }
+
+        if !acc.is_empty() {
+            chunks.push(acc);
+        }
+
+        if log::log_enabled!(log::Level::Info) {
+            for (i, chunk) in chunks.iter().enumerate() {
+                log::info!("Chunk {} has {} words", i, chunk.len(),);
+            }
+        }
+
+        Ok(CompFragment::Success(
+            chunks.into_iter().map(|chunk| chunk.join(" ")).collect(),
+        ))
+    }
+
+    fn send_to_golem(&self, chunks: CompFragment<Vec<String>>) -> Result<CompFragment<Task>> {
+        let chunks = match chunks {
+            CompFragment::Success(chunks) => chunks,
+            CompFragment::CtrlC => return Ok(CompFragment::CtrlC),
+        };
+
+        println!(
+            "{} {}Sending task to Golem...",
+            style("[2/4]").bold().dim(),
+            TRUCK
+        );
+
+        // prepare workspace
+        let mut workspace = env::temp_dir();
+        let time_now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_err(|e| e.to_string())?;
+        let subdir = format!("g_flite_{}", time_now.as_secs());
+        workspace.push(subdir);
+        fs::create_dir(workspace.as_path()).map_err(|e| {
+            format!(
+                "creating directory '{}': {}",
+                workspace.to_string_lossy(),
+                e
+            )
+        })?;
+
+        log::info!("Will prepare task in '{:?}'", workspace);
+
+        // prepare Golem task
+        let mut task_builder = TaskBuilder::new(
+            workspace,
+            self.bid,
+            self.task_timeout.to_string(),
+            self.subtask_timeout.to_string(),
+        );
+
+        for chunk in chunks {
+            task_builder.add_subtask(chunk);
+        }
+
+        let task = task_builder.build()?;
+
+        // connect to Golem
+        let mut sys = actix::System::new("g-flite");
+        let endpoint = sys
+            .block_on(golem_rpc_api::connect_to_app(
+                &self.datadir,
+                Some(golem_rpc_api::Net::TestNet),
+                Some((&self.address, self.port)),
+            ))
+            .map_err(|e| {
+                format!(
+                    "connecting to Golem with datadir='{:?}', net='{}', address='{}:{}': {}",
+                    self.datadir,
+                    golem_rpc_api::Net::TestNet,
+                    self.address,
+                    self.port,
+                    e
+                )
+            })?;
+
+        // TODO check if account is unlocked
+        // TODO check if terms are accepted
+
+        let resp = sys
+            .block_on(endpoint.as_golem_comp().create_task(task.json.clone()))
+            .map_err(|e| format!("creating Golem task '{:#?}': {}", task.json, e))?;
+        let task_id = resp.0.ok_or("extracting Golem task's id".to_owned())?;
+
+        // wait
+        println!(
+            "{} {}Waiting on compute to finish...",
+            style("[3/4]").bold().dim(),
+            HOURGLASS
+        );
+        let num_tasks = task.expected_output_paths.len() as u64;
+        let bar = ProgressBar::new(num_tasks);
+        bar.inc(0);
+        let mut old_progress = 0.0;
+
+        loop {
+            if self.abort.load(Ordering::Relaxed) {
+                sys.block_on(endpoint.as_golem_comp().abort_task(task_id.clone()))
+                    .map_err(|e| format!("cancelling task '{}': {}", task_id.clone(), e))?;
+                return Ok(CompFragment::CtrlC);
+            }
+
+            let resp = sys
+                .block_on(endpoint.as_golem_comp().get_task(task_id.clone()))
+                .map_err(|e| format!("polling for task '{}': {}", task_id.clone(), e))?;
+            let task_info = resp.ok_or("parsing task info from Golem".to_owned())?;
+
+            log::info!("Received task info from Golem: {:?}", task_info);
+
+            let progress = task_info
+                .progress
+                .ok_or("reading task's progress".to_owned())?
+                * 100.0;
+
+            if progress != old_progress {
+                let delta = (progress - old_progress) / 100.0;
+                old_progress = progress;
+                bar.inc((delta * num_tasks as f64).round() as u64);
+            }
+
+            match task_info.status {
+                comp::TaskStatus::Restarted => {
+                    // reset progress bar
+                    bar.inc(0);
+                    old_progress = 0.0;
+                }
+                comp::TaskStatus::Aborted => {
+                    return Err(
+                        "waiting for task to complete: task aborted by someone else".to_owned()
+                    )
+                }
+                comp::TaskStatus::Timeout => {
+                    return Err("waiting for task to complete: task timed out".to_owned())
+                }
+                comp::TaskStatus::Finished => break,
+                _ => {}
+            }
+
+            thread::sleep(Duration::from_secs(1));
+        }
+
+        Ok(CompFragment::Success(task))
+    }
+
+    fn combine_output(&self, task: CompFragment<Task>) -> Result<CompFragment<()>> {
+        let mut task = match task {
+            CompFragment::Success(task) => task,
+            CompFragment::CtrlC => return Ok(CompFragment::CtrlC),
+        };
+
+        let first = task
+            .expected_output_paths
+            .pop_front()
+            .ok_or("combining results: no results received from Golem".to_owned())?;
+
+        println!(
+            "{} {}Combining output into '{}'...",
+            style("[4/4]").bold().dim(),
+            CLIP,
+            self.output.to_string_lossy()
+        );
+
+        let reader = hound::WavReader::open(&first)
+            .map_err(|e| format!("opening WAVE file '{}': {}", first.to_string_lossy(), e))?;
+        let spec = reader.spec();
+
+        log::info!("Using Wav spec: {:?}", spec);
+
+        let mut writer = hound::WavWriter::create(&self.output, spec).map_err(|e| {
+            format!(
+                "creating WAVE file '{}': {}",
+                self.output.to_string_lossy(),
+                e
+            )
+        })?;
+        for sample in reader.into_samples::<i16>() {
+            sample
+                .and_then(|sample| writer.write_sample(sample))
+                .map_err(|e| {
+                    format!(
+                        "reading audio sample from file '{}': {}",
+                        first.to_string_lossy(),
+                        e
+                    )
+                })?;
+        }
+
+        for expected_file in task.expected_output_paths {
+            let reader = hound::WavReader::open(&expected_file).map_err(|e| {
+                format!(
+                    "opening WAVE file '{}': {}",
+                    expected_file.to_string_lossy(),
+                    e
+                )
+            })?;
+            for sample in reader.into_samples::<i16>() {
+                sample
+                    .and_then(|sample| writer.write_sample(sample))
+                    .map_err(|e| {
+                        format!(
+                            "reading audio sample from file '{}': {}",
+                            expected_file.to_string_lossy(),
+                            e
+                        )
+                    })?;
+            }
+        }
+
+        Ok(CompFragment::Success(()))
+    }
+
+    pub fn run(&self) -> Result<CompFragment<()>> {
+        // register for ctrl-c events
+        let abort = Arc::clone(&self.abort);
+        let _ = ctrlc::set_handler(move || {
+            abort.store(true, Ordering::Relaxed);
+        });
+
+        // run!
+        self.split_input()
+            .and_then(|chunks| self.send_to_golem(chunks))
+            .and_then(|task| self.combine_output(task))
+    }
+}
+
+impl TryFrom<Opt> for App {
+    type Error = String;
+
+    fn try_from(opt: Opt) -> std::result::Result<Self, Self::Error> {
+        // verify input exists
+        let input = opt.input;
+        if !input.is_file() {
+            return Err(format!(
+                "Input file '{:?}' doesn't exist. Did you make a typo anywhere?",
+                input
+            ));
+        }
+
+        // verify output path excluding topmost file exists
+        if let Some(parent) = opt.output.parent() {
+            let parent_str = parent.to_string_lossy();
+            if !parent_str.is_empty() && !parent.exists() {
+                return Err(format!(
+                    "Output path '{}' doesn't exist. Did you make a type anywhere?",
+                    parent_str,
+                ));
+            }
+        }
+        let output = opt.output;
+
+        let datadir = match opt.datadir {
+            Some(datadir) => datadir,
+            None => match appdirs::user_data_dir(Some("golem"), Some("golem"), false) {
+                Ok(datadir) => datadir.join("default"),
+                Err(_) => {
+                    return Err("
+                    No standard project app datadirs available.
+                    You'll need to specify path to your Golem datadir manually.
+                    "
+                    .to_owned())
+                }
+            },
+        };
+
+        let address = opt.address.clone();
+        let port = opt.port;
+        let subtasks = opt.subtasks;
+        let bid = opt.bid;
+        let task_timeout = opt.task_timeout;
+        let subtask_timeout = opt.subtask_timeout;
+        let abort = Arc::new(AtomicBool::new(false));
+
+        Ok(Self {
+            input,
+            output,
+            datadir,
+            address,
+            port,
+            subtasks,
+            bid,
+            task_timeout,
+            subtask_timeout,
+            abort,
+        })
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -174,7 +174,7 @@ impl App {
 
         loop {
             if self.abort.load(Ordering::Relaxed) {
-                sys.block_on(endpoint.as_golem_comp().abort_task(task_id.clone()))
+                sys.block_on(endpoint.as_golem_comp().delete_task(task_id.clone()))
                     .map_err(|e| format!("cancelling task '{}': {}", task_id.clone(), e))?;
                 return Ok(CompFragment::CtrlC);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,30 +1,15 @@
+mod app;
 mod task;
 mod timeout;
 
 pub type Result<T> = std::result::Result<T, String>;
 
-use console::{style, Emoji};
+use self::app::{App, CompFragment};
+use self::timeout::Timeout;
 use env_logger::{Builder, Env};
-use golem_rpc_api::comp::{self, AsGolemComp};
-use hound;
-use indicatif::ProgressBar;
-use std::env;
-use std::fs;
-use std::io::Read;
-use std::path;
-use std::process;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::thread;
-use std::time::Duration;
-use std::time::SystemTime;
+use std::convert::TryInto;
+use std::path::PathBuf;
 use structopt::StructOpt;
-use timeout::Timeout;
-
-static TRUCK: Emoji = Emoji("🚚  ", "");
-static CLIP: Emoji = Emoji("🔗  ", "");
-static PAPER: Emoji = Emoji("📃  ", "");
-static HOURGLASS: Emoji = Emoji("⌛  ", "");
 
 #[derive(Debug, StructOpt)]
 #[structopt(
@@ -35,11 +20,11 @@ static HOURGLASS: Emoji = Emoji("⌛  ", "");
 struct Opt {
     /// Input text file
     #[structopt(parse(from_os_str))]
-    input: path::PathBuf,
+    input: PathBuf,
 
     /// Output WAV file
     #[structopt(parse(from_os_str))]
-    output: path::PathBuf,
+    output: PathBuf,
 
     /// Sets number of Golem subtasks
     #[structopt(long = "subtasks", default_value = "6")]
@@ -63,7 +48,7 @@ struct Opt {
 
     /// Sets path to Golem datadir
     #[structopt(long = "datadir", parse(from_os_str))]
-    datadir: Option<path::PathBuf>,
+    datadir: Option<PathBuf>,
 
     /// Sets RPC address to Golem instance
     #[structopt(long = "address", default_value = "127.0.0.1")]
@@ -78,310 +63,25 @@ struct Opt {
     verbose: bool,
 }
 
-#[derive(Debug)]
-pub struct GolemOpt {
-    bid: f64,
-    task_timeout: Timeout,
-    subtask_timeout: Timeout,
-}
-
-impl From<&Opt> for GolemOpt {
-    fn from(opt: &Opt) -> Self {
-        Self {
-            bid: opt.bid,
-            task_timeout: opt.task_timeout,
-            subtask_timeout: opt.subtask_timeout,
-        }
-    }
-}
-
-fn split_textfile(textfile: &str, num_subtasks: usize) -> Result<Vec<String>> {
-    let mut contents = String::new();
-    fs::File::open(textfile)
-        .and_then(|mut f| f.read_to_string(&mut contents))
-        .map_err(|e| format!("reading from '{}': {}", textfile, e))?;
-
-    let word_count = contents.split_whitespace().count();
-
-    log::info!("Input text file has {} words", word_count);
-
-    println!(
-        "{} {}Splitting '{}' into {} Golem subtasks...",
-        style("[1/4]").bold().dim(),
-        PAPER,
-        textfile,
-        num_subtasks,
-    );
-
-    let mut chunks = Vec::with_capacity(num_subtasks);
-    let num_words = (word_count as f64 / num_subtasks as f64).ceil() as usize;
-
-    log::info!("Each chunk will have max {} words", num_words);
-
-    let mut acc = Vec::with_capacity(num_words);
-    for word in contents.split_whitespace() {
-        acc.push(word);
-
-        if acc.len() == num_words {
-            chunks.push(acc);
-            acc = Vec::with_capacity(num_words);
-            continue;
-        }
-    }
-
-    if !acc.is_empty() {
-        chunks.push(acc);
-    }
-
-    if log::log_enabled!(log::Level::Info) {
-        for (i, chunk) in chunks.iter().enumerate() {
-            log::info!("Chunk {} has {} words", i, chunk.len(),);
-        }
-    }
-
-    Ok(chunks.into_iter().map(|chunk| chunk.join(" ")).collect())
-}
-
-fn run_on_golem<S: AsRef<path::Path>>(
-    chunks: Vec<String>,
-    datadir: S,
-    address: &str,
-    port: u16,
-    golem_opt: GolemOpt,
-) -> Result<task::Task> {
-    println!(
-        "{} {}Sending task to Golem...",
-        style("[2/4]").bold().dim(),
-        TRUCK
-    );
-
-    // prepare workspace
-    let mut workspace = env::temp_dir();
-    let time_now = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map_err(|e| e.to_string())?;
-    let subdir = format!("g_flite_{}", time_now.as_secs());
-    workspace.push(subdir);
-    fs::create_dir(workspace.as_path()).map_err(|e| {
-        format!(
-            "creating directory '{}': {}",
-            workspace.to_string_lossy(),
-            e
-        )
-    })?;
-
-    log::info!("Will prepare task in '{:?}'", workspace);
-
-    // prepare Golem task
-    let mut task_builder = task::TaskBuilder::new(workspace, golem_opt);
-
-    for chunk in chunks {
-        task_builder.add_subtask(chunk);
-    }
-
-    let task = task_builder.build()?;
-
-    // connect to Golem
-    let mut sys = actix::System::new("g-flite");
-    let endpoint = sys
-        .block_on(golem_rpc_api::connect_to_app(
-            datadir.as_ref(),
-            Some(golem_rpc_api::Net::TestNet),
-            Some((address, port)),
-        ))
-        .map_err(|e| {
-            format!(
-                "connecting to Golem with datadir='{}', net='{}', address='{}:{}': {}",
-                datadir.as_ref().to_string_lossy(),
-                golem_rpc_api::Net::TestNet,
-                address,
-                port,
-                e
-            )
-        })?;
-
-    // TODO check if account is unlocked
-    // TODO check if terms are accepted
-
-    let resp = sys
-        .block_on(endpoint.as_golem_comp().create_task(task.json.clone()))
-        .map_err(|e| format!("creating Golem task '{:#?}': {}", task.json, e))?;
-    let task_id = resp.0.ok_or("extracting Golem task's id".to_owned())?;
-
-    // wait
-    println!(
-        "{} {}Waiting on compute to finish...",
-        style("[3/4]").bold().dim(),
-        HOURGLASS
-    );
-    let num_tasks = task.expected_output_paths.len() as u64;
-    let bar = ProgressBar::new(num_tasks);
-    bar.inc(0);
-    let mut old_progress = 0.0;
-
-    let terminate = Arc::new(AtomicBool::new(false));
-
-    let t = Arc::clone(&terminate);
-    let _ = ctrlc::set_handler(move || {
-        t.store(true, Ordering::Relaxed);
-    });
-
-    loop {
-        if terminate.load(Ordering::Relaxed) {
-            sys.block_on(endpoint.as_golem_comp().abort_task(task_id.clone()))
-                .map_err(|e| format!("cancelling task '{}': {}", task_id.clone(), e))?;
-            return Err("received Ctrl-C".to_owned());
-        }
-
-        let resp = sys
-            .block_on(endpoint.as_golem_comp().get_task(task_id.clone()))
-            .map_err(|e| format!("polling for task '{}': {}", task_id.clone(), e))?;
-        let task_info = resp.ok_or("parsing task info from Golem".to_owned())?;
-
-        log::info!("Received task info from Golem: {:?}", task_info);
-
-        let progress = task_info
-            .progress
-            .ok_or("reading task's progress".to_owned())?
-            * 100.0;
-
-        if progress != old_progress {
-            let delta = (progress - old_progress) / 100.0;
-            old_progress = progress;
-            bar.inc((delta * num_tasks as f64).round() as u64);
-        }
-
-        match task_info.status {
-            comp::TaskStatus::Restarted => {
-                // reset progress bar
-                bar.inc(0);
-                old_progress = 0.0;
-            }
-            comp::TaskStatus::Aborted => {
-                return Err("waiting for task to complete: task aborted".to_owned())
-            }
-            comp::TaskStatus::Timeout => {
-                return Err("waiting for task to complete: task timed out".to_owned())
-            }
-            comp::TaskStatus::Finished => break,
-            _ => {}
-        }
-
-        thread::sleep(Duration::from_secs(1));
-    }
-
-    Ok(task)
-}
-
-fn combine_wave(mut task: task::Task, output_wavefile: &str) -> Result<()> {
-    let first = task
-        .expected_output_paths
-        .pop_front()
-        .ok_or("combining results: no results received from Golem".to_owned())?;
-
-    println!(
-        "{} {}Combining output into '{}'...",
-        style("[4/4]").bold().dim(),
-        CLIP,
-        output_wavefile
-    );
-
-    let reader = hound::WavReader::open(&first)
-        .map_err(|e| format!("opening WAVE file '{}': {}", first.to_string_lossy(), e))?;
-    let spec = reader.spec();
-
-    log::info!("Using Wav spec: {:?}", spec);
-
-    let mut writer = hound::WavWriter::create(output_wavefile, spec)
-        .map_err(|e| format!("creating WAVE file '{}': {}", output_wavefile, e))?;
-    for sample in reader.into_samples::<i16>() {
-        sample
-            .and_then(|sample| writer.write_sample(sample))
-            .map_err(|e| {
-                format!(
-                    "reading audio sample from file '{}': {}",
-                    first.to_string_lossy(),
-                    e
-                )
-            })?;
-    }
-
-    for expected_file in task.expected_output_paths {
-        let reader = hound::WavReader::open(&expected_file).map_err(|e| {
-            format!(
-                "opening WAVE file '{}': {}",
-                expected_file.to_string_lossy(),
-                e
-            )
-        })?;
-        for sample in reader.into_samples::<i16>() {
-            sample
-                .and_then(|sample| writer.write_sample(sample))
-                .map_err(|e| {
-                    format!(
-                        "reading audio sample from file '{}': {}",
-                        expected_file.to_string_lossy(),
-                        e
-                    )
-                })?;
-        }
-    }
-
-    Ok(())
-}
-
 fn main() {
     let opt = Opt::from_args();
-
-    // unpack config args
-    let golem_opt: GolemOpt = (&opt).into();
-    let subtasks = opt.subtasks;
-    let address = opt.address;
-    let port = opt.port;
-    let datadir = opt.datadir.unwrap_or_else(|| {
-        match appdirs::user_data_dir(Some("golem"), Some("golem"), false) {
-            Ok(data_dir) => data_dir.join("default"),
-            Err(_) => {
-                eprintln!(
-                    "No standard project app data dirs available. Are you running a supported OS?"
-                );
-                process::exit(1);
-            }
-        }
-    });
 
     if opt.verbose {
         Builder::from_env(Env::default().default_filter_or("info")).init();
     }
 
-    // verify input exists
-    let input = opt.input.to_string_lossy().to_owned();
-    if !opt.input.is_file() {
-        eprintln!(
-            "Input file '{}' doesn't exist. Did you make a typo anywhere?",
-            input
-        );
-        process::exit(1);
-    }
-
-    // verify output path excluding topmost file exists
-    if let Some(parent) = opt.output.parent() {
-        let parent_str = parent.to_string_lossy();
-        if !parent_str.is_empty() && !parent.exists() {
-            eprintln!(
-                "Output path '{}' doesn't exist. Did you make a type anywhere?",
-                parent_str,
-            );
-            process::exit(1);
+    match opt.try_into().and_then(|app: App| app.run()) {
+        Ok(CompFragment::Success(_)) => {
+            // computation finished uninterrupted and results were pooled together successfully
+            println!("Success")
         }
-    }
-    let output = opt.output.to_string_lossy().to_owned();
-
-    if let Err(err) = split_textfile(&input, subtasks)
-        .and_then(|chunks| run_on_golem(chunks, datadir, &address, port, golem_opt))
-        .and_then(|task| combine_wave(task, &output))
-    {
-        eprintln!("An error occurred while {}", err);
-        process::exit(1);
+        Ok(CompFragment::CtrlC) => {
+            // computation was cancelled by the user
+            println!("Aborted by user (did you press ctrl-c?)")
+        }
+        Err(err) => {
+            // unexpected error occurred
+            eprintln!("An error occurred while {}", err)
+        }
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,4 +1,4 @@
-use super::{GolemOpt, Result};
+use super::Result;
 use serde_json::{json, Map, Value};
 use std::collections::{BTreeMap, VecDeque};
 use std::fs;
@@ -21,11 +21,16 @@ pub struct TaskBuilder {
 }
 
 impl TaskBuilder {
-    pub fn new<S: AsRef<Path>>(workspace: S, opt: GolemOpt) -> Self {
+    pub fn new<P: AsRef<Path>, S: AsRef<str>>(
+        workspace: P,
+        bid: f64,
+        task_timeout: S,
+        subtask_timeout: S,
+    ) -> Self {
         Self {
-            bid: opt.bid,
-            task_timeout: opt.task_timeout.to_string(),
-            subtask_timeout: opt.subtask_timeout.to_string(),
+            bid,
+            task_timeout: task_timeout.as_ref().to_owned(),
+            subtask_timeout: subtask_timeout.as_ref().to_owned(),
             js_name: "flite.js".into(),
             wasm_name: "flite.wasm".into(),
             input_dir_path: workspace.as_ref().join("in"),


### PR DESCRIPTION
This PR introduces a handler for Ctrl-C interrupt. The app upon receiving the signal should cancel the Golem task, and return.

This PR resolves #2.

There is one caveat though. Cancelling task is equivalent to deleting it from history in Golem. That is, we hook to `comp.task.delete` RPC cmd instead of `comp.task.abort` which would seem like a better choice. However, the latter while cancelling the task, it doesn't unlock the payments, and as far as I could tell, it's not possible to then resurrect the task after it was "aborted". So, for the moment, until this gets thought out at the Golem level, Ctrl-C in `g-flite` will be equivalent to "deleting" the task from the Golem node.